### PR TITLE
Corrigindo protNfe

### DIFF
--- a/lib/src/models/danfe.dart
+++ b/lib/src/models/danfe.dart
@@ -40,7 +40,7 @@ class Danfe {
           ? DadosDanfe.fromMap(parseMap['infNFe'])
           : null,
       tipo: 'NFe',
-      protNFe: parseMap['protNFe'] != null
+      protNFe: map['protNFe'] != null
           ? ProtNFe.fromMap(parseMap['protNFe'])
           : null,
       infNFeSupl: parseMap['infNFeSupl'] != null


### PR DESCRIPTION
O protNFe não fica dentro do NFe, então na comparação fica nulo
![image](https://github.com/brasizza/danfe-package/assets/99298569/87868ca5-3615-443d-aae0-1e0ff3928337)
