### PR TITLE
Ajustado para que acréscimo também seja mapeado de `DescAcrEntr`

### DIFF
--- a/lib/src/models/total.dart
+++ b/lib/src/models/total.dart
@@ -28,15 +28,20 @@ class Total {
 
   factory Total.fromMap(Map<String, dynamic> map) {
     String? desconto;
+    String? acrescimo;
+
     if (map.containsKey('vCFe')) {
       if (map.containsKey('DescAcrEntr')) {
         desconto = map['DescAcrEntr']?['vDescSubtot'];
+        acrescimo = map['DescAcrEntr']?['vAcresSubtot'];
       } else {
         desconto = map['ICMSTot']['vDesc'];
+        acrescimo = map['ICMSTot']['vOutro'];
       }
     } else {
       if (map.containsKey('ICMSTot')) {
         desconto = map['ICMSTot']['vDesc'];
+        acrescimo = map['ICMSTot']['vOutro'];
       }
     }
 
@@ -49,9 +54,7 @@ class Total {
       valorLei12741:
           map.containsKey('vCFeLei12741') ? map['vCFeLei12741'] : '0.00',
       desconto: desconto ?? '0.00',
-      acrescimo: (map.containsKey('vCFe')
-          ? map['ICMSTot']['vOutro']
-          : map['ICMSTot']['vOutro']),
+      acrescimo: acrescimo ?? '0.00',
       valorPago:
           ((map.containsKey('vCFe') ? map['vCFe'] : map['ICMSTot']['vNF'])) ??
               '0.00',


### PR DESCRIPTION
O valor de acréscimo não estava sendo mapeado corretamente; na verdade, havia um `if` redundante que não verificava se existia um valor de acréscimo definido em `DescAcrEntr > vAcresSubtot`. Ajustei para que agora o `fromMap` pegue o valor de acréscimo, se definido. 